### PR TITLE
adds socket host as environment variable

### DIFF
--- a/electron-service/index.js
+++ b/electron-service/index.js
@@ -8,7 +8,7 @@ const terminate = () => {
 	app.quit();
 };
 
-sock.connect(parseInt(process.env.ELECTRON_SCREENSHOT_PORT, 10));
+sock.connect(parseInt(process.env.ELECTRON_SCREENSHOT_PORT, 10),  process.env.HOST || 'localhost');
 
 app.on('window-all-closed', () => {});
 app.on('ready', () => {


### PR DESCRIPTION
on windows, there is an issue when connecting to the sockets. 

```
Uncaught Exception:
Error: connect EADDRNOTAVAIL 0.0.0.0:7601
	at Object.exports._errnoException (util.js:949:11)
	at exports._exceptionWithHostPort (util.js:972:20)
	at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1080:14)
```

by specifying HOST as "127.0.0.1" this is solved